### PR TITLE
Define request id alias

### DIFF
--- a/examples_test.go
+++ b/examples_test.go
@@ -120,3 +120,23 @@ func ExampleZapLogWithConfig() {
 
 	e.Use(middleware.ZapLogWithConfig(logConfig))
 }
+
+// This example registers the RequestID middleware with default configuration.
+func ExampleRequestID() {
+	e := echo.New()
+
+	// Middleware
+	e.Use(middleware.RequestID())
+}
+
+// This example registers the RequestID middleware with custom configuration.
+func ExampleRequestIDWithConfig() {
+	e := echo.New()
+
+	// Middleware
+	config := middleware.RequestIDConfig{
+		TargetHeader: echo.HeaderXRequestID,
+	}
+
+	e.Use(middleware.RequestIDWithConfig(config))
+}

--- a/request_id.go
+++ b/request_id.go
@@ -13,9 +13,12 @@ type ctxkey struct{ name string }
 // reqIDKey key used to store the request-id in context.
 var reqIDKey = &ctxkey{"request-id"}
 
+// RequestIDConfig alias for emw.RequestIDConfig
+type RequestIDConfig = emw.RequestIDConfig
+
 // DefaultRequestIDConfig is the default RequestID middleware config, based on
 // the echo.RequestIDConfig but with uuid generator instead.
-var DefaultRequestIDConfig = emw.RequestIDConfig{
+var DefaultRequestIDConfig = RequestIDConfig{
 	Skipper:          emw.DefaultSkipper,
 	Generator:        uuidGen,
 	RequestIDHandler: requestIDHandler,
@@ -30,7 +33,7 @@ func RequestID() echo.MiddlewareFunc {
 
 // RequestIDWithConfig uses the echo.RequestIDWithConfig under the hood with
 // custom generator and sets the request id in context.
-func RequestIDWithConfig(cfg emw.RequestIDConfig) echo.MiddlewareFunc {
+func RequestIDWithConfig(cfg RequestIDConfig) echo.MiddlewareFunc {
 	// Defaults
 	if cfg.Skipper == nil {
 		cfg.Skipper = emw.DefaultRequestIDConfig.Skipper

--- a/request_id_test.go
+++ b/request_id_test.go
@@ -4,13 +4,12 @@ import (
 	"testing"
 
 	"github.com/labstack/echo/v4"
-	emw "github.com/labstack/echo/v4/middleware"
 )
 
 func TestRequestIDWithConfig(t *testing.T) {
 	ec := reqCtx(t)
 
-	cfg := emw.RequestIDConfig{}
+	cfg := RequestIDConfig{}
 	_ = RequestIDWithConfig(cfg)(testHandler)(ec)
 
 	rid := RequestIDValue(ec.Request().Context())


### PR DESCRIPTION
Instead of using the `echo.RequestIDConfig` directly, an alias was created to make the usage more simple.